### PR TITLE
[MWPW-176119][MWPW-176339] acom is required as a default Global-Nav for all our pages and footer is not visible in stage.adobe.com

### DIFF
--- a/genuine/scripts/scripts.js
+++ b/genuine/scripts/scripts.js
@@ -128,7 +128,7 @@ const locales = {
 
 // Add any config options.
 const CONFIG = {
-  contentRoot: '/genuine-content',
+  contentRoot: '/genuine-shared',
   codeRoot: '/genuine',
   imsClientId: 'adobedotcom-cc',
   locales,


### PR DESCRIPTION
* Changed the config root from /genuine-content to /genuine-shared

Resolves: [MWPW-176119](https://jira.corp.adobe.com/browse/MWPW-176119) and [MWPW-176339](https://jira.corp.adobe.com/browse/MWPW-176339)

**Test URLs:**
- Before: https://main--genuine--adobecom.hlx.live/drafts/siva/example?martech=off
- After: https://gnav-bug--genuine--sivasadobe.hlx.live/drafts/siva/example?martech=off
