### PR TITLE
MWPW-184656: Enabled query parameters propagation from parent page to localnav

### DIFF
--- a/genuine/scripts/decorate.js
+++ b/genuine/scripts/decorate.js
@@ -19,8 +19,8 @@ function goCartLinkAppend(link, paramsValue) {
 }
 
 export function decorateButton() {
-  // Include all links in body - gnav + main
-  const links = document.querySelector('body').querySelectorAll('a:not([href^="tel:"])');
+  // Include links in header-localnav and main
+  const links = document.querySelectorAll('header.localnav a:not([href^="tel:"]), main a:not([href^="tel:"])');
   const cache = document.head.querySelector('meta[name="cache"]');
   const paramsValue = getUrlParams();
   if (cache?.content === 'on' && Object.keys(paramsValue).length > 0) {

--- a/genuine/scripts/decorate.js
+++ b/genuine/scripts/decorate.js
@@ -19,7 +19,8 @@ function goCartLinkAppend(link, paramsValue) {
 }
 
 export function decorateButton() {
-  const links = document.querySelector('main').querySelectorAll('a:not([href^="tel:"])');
+  // Include all links in body - gnav + main
+  const links = document.querySelector('body').querySelectorAll('a:not([href^="tel:"])');
   const cache = document.head.querySelector('meta[name="cache"]');
   const paramsValue = getUrlParams();
   if (cache?.content === 'on' && Object.keys(paramsValue).length > 0) {

--- a/genuine/scripts/decorate.js
+++ b/genuine/scripts/decorate.js
@@ -20,7 +20,7 @@ function goCartLinkAppend(link, paramsValue) {
 
 export function decorateButton() {
   // Include links in header-localnav and main
-  const links = document.querySelectorAll('header.localnav a:not([href^="tel:"]), main a:not([href^="tel:"])');
+  const links = document.querySelectorAll('header.local-nav a:not([href^="tel:"]), main a:not([href^="tel:"])');
   const cache = document.head.querySelector('meta[name="cache"]');
   const paramsValue = getUrlParams();
   if (cache?.content === 'on' && Object.keys(paramsValue).length > 0) {


### PR DESCRIPTION
* Updated link decoration scope by modifying `decorateButton()` to include links in header (localnav) and main.
> Note that links in `footer` are skipped

Resolves: [MWPW-184656](https://jira.corp.adobe.com/browse/MWPW-184656)

**Test URLs:**
- Before: https://main--genuine--adobecom.aem.page/genuine/dm-ses-lp/shop?gid=1BKVUDQIDF&gtoken=f37e2aa5-d86f-42cb-9c3e-d5bb723cf42a&sdid=90
- After: https://mwpw-184656-query-params--genuine--adobecom.aem.page/genuine/dm-ses-lp/shop?gid=1BKVUDQIDF&gtoken=f37e2aa5-d86f-42cb-9c3e-d5bb723cf42a&sdid=90

**Dev validation**
_Header LocalNav_
<img width="1101" height="1045" alt="Screenshot 2025-12-19 at 2 56 17 PM" src="https://github.com/user-attachments/assets/b6cabc39-77b7-4b05-b0bf-90646c52b76b" />


_Main_
<img width="1355" height="1033" alt="Screenshot 2025-12-19 at 2 57 03 PM" src="https://github.com/user-attachments/assets/892c6e5e-d59d-4efb-a108-f42369fb6424" />


_Footer_
<img width="723" height="1039" alt="Screenshot 2025-12-19 at 2 57 47 PM" src="https://github.com/user-attachments/assets/ca7a26dc-f73d-4903-b1b3-8df14d0b11ef" />
