### PR TITLE
MWPW-185562: Updated default endpoint to GC if serviceName parameter is missing

### DIFF
--- a/genuine/scripts/goCart.js
+++ b/genuine/scripts/goCart.js
@@ -20,7 +20,7 @@ export async function isTokenValid() {
   const urlParams = new URLSearchParams(window.location.search);
   const gtoken = urlParams.get('gtoken');
   const gid = urlParams.get('gid');
-  const serviceName = urlParams.get('serviceName') || 'genuine';
+  const serviceName = urlParams.get('serviceName') || 'gc';
   const envName = urlParams.get('env');
   const { codeRoot } = getConfig();
   const serviceConf = await getServiceConfig(codeRoot);

--- a/genuine/scripts/goCart.js
+++ b/genuine/scripts/goCart.js
@@ -70,7 +70,7 @@ export async function loadBFP(umi) {
         const deviceId = { type: 'umi', value: umi };
         components.metaData = {
           ...components.metaData,
-          meta: { deviceId: JSON.stringify(deviceId)},
+          meta: { deviceId: JSON.stringify(deviceId) },
         };
         const payload = { ...components, version };
         return window.BFPJS.publish(payload);


### PR DESCRIPTION
* Fallback serviceName has been updated to "gc"

Resolves: [MWPW-185562](https://jira.corp.adobe.com/browse/MWPW-185562)

**Test URLs:**
- Before: https://main--genuine--adobecom.aem.page/?martech=off
- After: https://MWPW-185562-default-gc--genuine--adobecom.aem.page/?martech=off

**Dev validation (by overriding)**
URL - https://www.stage.adobe.com/genuine/test-genuine-page.html?gid=1BKVUDQIDF&gtoken=f37e2aa5-d86f-42cb-9c3e-d5bb723cf42a&env=stage
<img width="1869" height="548" alt="Screenshot 2025-12-23 at 2 51 26 PM" src="https://github.com/user-attachments/assets/aebadc87-5112-422d-8caf-1fbd716e31d6" />
