### PR TITLE
MWPW-185771: Enable authoring customizations for Ribbon Block

### DIFF
--- a/genuine/blocks/ribbon/ribbon.css
+++ b/genuine/blocks/ribbon/ribbon.css
@@ -1,15 +1,34 @@
+/* Responsive styling with mobile/tablet-first approach */
+
 :root {
-    --ribbon-height: 48px;
     --ribbon-padding-x: 20px;
-    --logo-width: 66px;
-    --close-button-width: 20px;
+
+    /* Spacing tokens for vertical padding */
+    --spacing-xxxs: 8px;
+    --spacing-xxs: 16px;
+    --spacing-xs: 24px;
+    --spacing-sm: 32px;
+    --spacing-md: 40px;
+    --spacing-lg: 56px;
+    --spacing-xl: 48px;
+    --spacing-xxl: 56px;
+    --spacing-xxxl: 80px;
+
+    /* Logo and close icon size tokens */
+    --icon-xxs: 16px;
+    --icon-xs: 24px;
+    --icon-sm: 32px;
+    --icon-md: 40px;
+    --icon-lg: 56px;
+    --icon-xl: 64px;
+    --icon-xxl: 80px;
 }
 
 .ribbon-container {
     display: flex;
     align-items: center;
-    padding: 0 var(--ribbon-padding-x);
-    height: var(--ribbon-height);
+    padding-inline: var(--ribbon-padding-x); /* Horizontal padding */
+    padding-block: var(--spacing-xxxs); /* Default vertical spacing */
     width: 100%;
     box-sizing: border-box;
     justify-content: space-between;
@@ -21,11 +40,11 @@
 }
 
 .ribbon-logo img {
-    width: var(--logo-width);
+    width: var(--icon-lg); /* Default logo icon size */
 }
 
 .ribbon-close img {
-    width: var(--close-button-width);
+    width: var(--icon-xxs); /* Default close icon size */
 }
 
 .ribbon-content {
@@ -37,5 +56,43 @@
 
 .ribbon-close {
     display: flex;
-    justify-content: end;
+    justify-content: flex-end;
+}
+
+/* Spacing classes for vertical padding */
+.ribbon-container.xxxs-spacing { padding-block: var(--spacing-xxxs); }
+.ribbon-container.xxs-spacing { padding-block: var(--spacing-xxs); }
+.ribbon-container.xs-spacing { padding-block: var(--spacing-xs); }
+.ribbon-container.sm-spacing { padding-block: var(--spacing-sm); }
+.ribbon-container.md-spacing { padding-block: var(--spacing-md); }
+.ribbon-container.lg-spacing { padding-block: var(--spacing-lg); }
+.ribbon-container.xl-spacing { padding-block: var(--spacing-xl); }
+.ribbon-container.xxl-spacing { padding-block: var(--spacing-xxl); }
+.ribbon-container.xxxl-spacing { padding-block: var(--spacing-xxxl); }
+
+/* Logo icon size classes */
+.ribbon-logo.xxs-logo-icon img { width: var(--icon-xxs); }
+.ribbon-logo.xs-logo-icon img { width: var(--icon-xs); }
+.ribbon-logo.sm-logo-icon img { width: var(--icon-sm); }
+.ribbon-logo.md-logo-icon img { width: var(--icon-md); }
+.ribbon-logo.lg-logo-icon img { width: var(--icon-lg); }
+.ribbon-logo.xl-logo-icon img { width: var(--icon-xl); }
+.ribbon-logo.xxl-logo-icon img { width: var(--icon-xxl); }
+
+/* Close icon size classes */
+.ribbon-close.xxs-close-icon img { width: var(--icon-xxs); }
+.ribbon-close.xs-close-icon img { width: var(--icon-xs); }
+.ribbon-close.sm-close-icon img { width: var(--icon-sm); }
+.ribbon-close.md-close-icon img { width: var(--icon-md); }
+.ribbon-close.lg-close-icon img { width: var(--icon-lg); }
+.ribbon-close.xl-close-icon img { width: var(--icon-xl); }
+.ribbon-close.xxl-close-icon img { width: var(--icon-xxl); }
+
+/* Desktop styles */
+@media screen and (min-width: 900px) {
+    :root {
+        --spacing-xl: 56px;
+        --spacing-xxl: 80px;
+        --spacing-xxxl: 104px;
+    }
 }

--- a/genuine/blocks/ribbon/ribbon.js
+++ b/genuine/blocks/ribbon/ribbon.js
@@ -1,5 +1,13 @@
 import { createTag } from '../../scripts/utils.js';
 
+// ===== CONFIGURATION =====
+
+const CONFIG = {
+  DEFAULT_SPACING: 'xxxs-spacing',
+  DEFAULT_LOGO_ICON: 'lg-logo-icon',
+  DEFAULT_CLOSE_ICON: 'xxs-close-icon',
+};
+
 const LANA_OPTIONS = { tags: 'ribbon', errorType: 'i' };
 
 // ===== UTILITY FUNCTIONS =====
@@ -7,6 +15,23 @@ const LANA_OPTIONS = { tags: 'ribbon', errorType: 'i' };
 function logError(message, error) {
   window.lana?.log(`${message}: ${error}`, LANA_OPTIONS);
 }
+
+// ===== PARAMS PARSING FUNCTIONS =====
+
+function getBlockClasses(block) {
+  const classList = Array.from(block.classList);
+  const spacingClass = classList.find((cls) => cls.endsWith('-spacing')) || CONFIG.DEFAULT_SPACING;
+  const logoIconClass = classList.find((cls) => cls.endsWith('-logo-icon')) || CONFIG.DEFAULT_LOGO_ICON;
+  const closeIconClass = classList.find((cls) => cls.endsWith('-close-icon')) || CONFIG.DEFAULT_CLOSE_ICON;
+
+  return {
+    spacing: spacingClass,
+    logoIcon: logoIconClass,
+    closeIcon: closeIconClass,
+  };
+}
+
+// ===== DOM BUILDING FUNCTIONS =====
 
 function createRibbonContainer() {
   const container = createTag('div', { class: 'ribbon-container' });
@@ -63,6 +88,8 @@ function processCloseSection(closeSection, closeWrapper) {
   }
 }
 
+// ===== MAIN FUNCTION =====
+
 export default function decorate(block) {
   if (!block) return;
 
@@ -73,6 +100,12 @@ export default function decorate(block) {
     const closeSection = sections[2]; // Close button
 
     const { container, logoWrapper, contentWrapper, closeWrapper } = createRibbonContainer();
+
+    // Apply size classes for spacing, logo-icon and close-icon
+    const classes = getBlockClasses(block);
+    container.classList.add(classes.spacing);
+    logoWrapper.classList.add(classes.logoIcon);
+    closeWrapper.classList.add(classes.closeIcon);
 
     // Processing each section
     processLogoSection(logoSection, logoWrapper);


### PR DESCRIPTION
- Enable authoring customizations for Ribbon Block - Authors can now control spacing and icon sizes via CSS classes
- Add spacing control system - Support for 9 spacing variants (xxxs-xxxl) for vertical padding adjustments
- Add icon size configuration - 7 size options for logo and close icons with responsive breakpoints
- Refactor block structure - Modular functions with error handling for better maintainability
- Support intuitive class syntax - Simple {size}-spacing and {size}-icon naming for authoring tools
- Defaults are - `xxxs-spacing`, `lg-logo-icon` and `xxs-close-icon`

Resolves: [MWPW-185771](https://jira.corp.adobe.com/browse/MWPW-185771)

**Test URLs:**
- Before: https://stage--genuine--adobecom.aem.live/genuine/drafts/harshad/fragments/ribbon
- After: https://MWPW-185771-ribbon--genuine--adobecom.aem.live/genuine/drafts/harshad/fragments/ribbon

**Dev validation:**
<img width="1372" height="241" alt="Screenshot 2026-01-07 at 1 01 38 AM" src="https://github.com/user-attachments/assets/5247106a-eff6-48a2-b874-384082bc6fc5" />

**DOM**
<img width="566" height="122" alt="Screenshot 2026-01-07 at 1 02 39 AM" src="https://github.com/user-attachments/assets/ba0a70cc-caa5-4077-8c49-6f8fd72a95fc" />

**Authoring**
<img width="699" height="147" alt="Screenshot 2026-01-07 at 1 03 00 AM" src="https://github.com/user-attachments/assets/8708e6e4-b949-4c15-853b-7539907ad749" />

> Reference for tokens (spacing and icons) - https://milo.adobe.com/docs/authoring/consonant/font-space-token

