### PR TITLE
MWPW-185773 Support for Genuine Blocks in library

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -6,6 +6,7 @@
       "title": "Library",
       "environments": [ "edit" ],
       "isPalette": true,
+      "passConfig": true,
       "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 398px; width: 360px;",
       "url": "https://milo.adobe.com/tools/library",
       "includePaths": [ "**.docx**" ]


### PR DESCRIPTION
> Note: This could be validated E2E on production only
> Additionally,
> 1. There is an existing issue in milo, which needs to be resolved as well (reference - https://adobe-mwp.slack.com/archives/C03HAU5SU2E/p1767732253053689)
> 2. This will also require some authoring on genuine sharepoint folder; which we will setup and then tweaks could be done by authoring team

* Passing configuration as URL query parameters while loading library markup, which loads genuine-specific config for custom blocks

Resolves: [MWPW-185773 ](https://jira.corp.adobe.com/browse/MWPW-185773 )

**Test URLs:**
- Before: https://main--genuine--adobecom.aem.page/?martech=off
- After: https://MWPW-185773-library--genuine--adobecom.aem.page/?martech=off

**Dev validation (by spoofing)**
<img width="861" height="325" alt="Screenshot 2026-01-07 at 10 21 46 AM" src="https://github.com/user-attachments/assets/22da3454-8a0f-4cf9-9200-c69d5323110b" />

