### PR TITLE
MWPW-185837 Add disabled link support using "#_disabled" hash

### DIFF
--- a/genuine/scripts/decorate.js
+++ b/genuine/scripts/decorate.js
@@ -1,5 +1,23 @@
 import { getUrlParams } from './utils.js';
 
+const DISABLED_HASH = '#_disabled';
+
+function processDisabledLink(link) {
+  const href = link.getAttribute('href');
+  if (!href?.includes(DISABLED_HASH)) return false;
+
+  link.classList.add('link-disabled');
+  link.setAttribute('href', href.replace(DISABLED_HASH, ''));
+  link.setAttribute('aria-disabled', 'true');
+  link.setAttribute('tabindex', '-1');
+
+  const img = link.querySelector('img');
+  const ariaLabel = img?.alt ? `${img.alt}` : 'disabled link';
+
+  link.setAttribute('aria-label', ariaLabel);
+  return true;
+}
+
 function goCartLinkAppend(link, paramsValue) {
   try {
     const url = new URL(link.getAttribute('href'), window.location.origin);
@@ -18,19 +36,27 @@ function goCartLinkAppend(link, paramsValue) {
   }
 }
 
-export function decorateButton() {
+export function decorateLinks() {
   // Include links in header-localnav and main
   const links = document.querySelectorAll('header.local-nav a:not([href^="tel:"]), main a:not([href^="tel:"])');
   const cache = document.head.querySelector('meta[name="cache"]');
   const paramsValue = getUrlParams();
-  if (cache?.content === 'on' && Object.keys(paramsValue).length > 0) {
-    links.forEach((link) => goCartLinkAppend(link, paramsValue));
-  }
+  const shouldAppendParams = cache?.content === 'on' && Object.keys(paramsValue).length > 0;
+
+  links.forEach((link) => {
+    if (!processDisabledLink(link) && shouldAppendParams) {
+      goCartLinkAppend(link, paramsValue);
+    }
+  });
 
   const observer = new MutationObserver((_, obs) => {
     const localNav = document.querySelector('header.local-nav');
     if (!localNav) return;
-    document.querySelectorAll('header.local-nav a:not([href^="tel:"])').forEach((link) => goCartLinkAppend(link, paramsValue));
+    document.querySelectorAll('header.local-nav a:not([href^="tel:"])').forEach((link) => {
+      if (!processDisabledLink(link) && shouldAppendParams) {
+        goCartLinkAppend(link, paramsValue);
+      }
+    });
     obs.disconnect();
   });
 

--- a/genuine/scripts/scripts.js
+++ b/genuine/scripts/scripts.js
@@ -14,7 +14,7 @@ import { setLibs, getUrlParams } from './utils.js';
 
 import { isTokenValid, loadBFP } from './goCart.js';
 
-import { decorateButton } from './decorate.js';
+import { decorateLinks } from './decorate.js';
 
 const STYLES = '/genuine/styles/styles.css';
 
@@ -182,7 +182,7 @@ setConfig({ ...CONFIG, miloLibs });
 async function loadGenuinePage() {
   loadLana({ clientId: 'genuine' });
   await loadArea();
-  decorateButton();
+  decorateLinks();
   const umi = new URLSearchParams(window.location.search).get('umi');
   if (umi) loadBFP(umi);
 }

--- a/genuine/styles/styles.css
+++ b/genuine/styles/styles.css
@@ -6,6 +6,9 @@
  * 
  *
  */
+ :root {
+  --link-disabled-color: #6e6e6e;
+ }
 
  .reading-width {
   max-width: 600px;
@@ -22,4 +25,17 @@
  .reading-width-footer-tag > .content {
   max-width: var(--grid-container-width);
   margin: 0 auto;
+}
+
+.link-disabled {
+  cursor: not-allowed;
+  color: var(--link-disabled-color) !important;
+  text-decoration: none !important;
+  pointer-events: none;
+}
+
+.link-disabled:hover,
+.link-disabled:focus {
+  text-decoration: none !important;
+  color: var(--link-disabled-color) !important;
 }


### PR DESCRIPTION
- decorate.js: Added a `processDisabledLink` function that detects links with `#_disabled` hash, adds styling classes, and sets accessibility attributes
- scripts.js: Renamed `decorateButton` to `decorateLinks`
- styles.css: Added CSS styles for disabled links with correct visual and interaction states

Resolves: [MWPW-185837](https://jira.corp.adobe.com/browse/MWPW-185837)

**Test URLs:**
- Before: https://stage--genuine--adobecom.aem.page/genuine/drafts/harshad/fragments/ribbon?gid=1BKVUDQIDF&gtoken=f37e2aa5-d86f-42cb-9c3e-d5bb723cf42a&sdid=90&martech=off
- After: https://MWPW-185837-disabled-links--genuine--adobecom.aem.page/genuine/drafts/harshad/fragments/ribbon?gid=1BKVUDQIDF&gtoken=f37e2aa5-d86f-42cb-9c3e-d5bb723cf42a&sdid=90&martech=off

**Dev validation:**
**Authoring**
<img width="727" height="377" alt="Screenshot 2026-01-07 at 8 43 53 PM" src="https://github.com/user-attachments/assets/12d727ca-d3f8-4676-b770-ff3e2877c463" />

**DOM changes**
<img width="1876" height="428" alt="Screenshot 2026-01-07 at 8 44 46 PM" src="https://github.com/user-attachments/assets/01a33fcf-a1ac-43c1-a76c-39e7330a107e" />
