### PR TITLE
MWPW-186252 Fixing media issue in root page

### DIFF
--- a/genuine/scripts/scripts.js
+++ b/genuine/scripts/scripts.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { setLibs, getUrlParams } from './utils.js';
+import { setLibs, getUrlParams, decorateArea } from './utils.js';
 
 import { isTokenValid, loadBFP } from './goCart.js';
 
@@ -199,6 +199,8 @@ async function loadGenuinePage() {
     document.head.appendChild(link);
   });
 }());
+
+decorateArea();
 
 (async function loadPage() {
   const validate = document.head.querySelector('meta[name="validate"]');

--- a/genuine/scripts/utils.js
+++ b/genuine/scripts/utils.js
@@ -92,3 +92,28 @@ export function getUrlParams() {
     return acc;
   }, {});
 }
+
+function getDecorateAreaFn() {
+  function isRootPage() {
+    const currUrl = new URL(window.location);
+    const pathSeg = currUrl.pathname.split('/').length;
+    const locale = getConfig().locale?.prefix;
+    return (locale === '' && pathSeg < 3) || (locale !== '' && pathSeg < 4);
+  }
+
+  function replaceDotMedia(area = document) {
+    const resetAttributeBase = (tag, attr) => {
+      area.querySelectorAll(`${tag}[${attr}^="./media_"]`).forEach((el) => {
+        el[attr] = `${new URL(`${getConfig().contentRoot}${el.getAttribute(attr).substring(1)}`, window.location).href}`;
+      });
+    };
+    resetAttributeBase('img', 'src');
+    resetAttributeBase('source', 'srcset');
+  }
+
+  return (area) => {
+    if (isRootPage()) replaceDotMedia(area);
+  };
+}
+
+export const decorateArea = getDecorateAreaFn();


### PR DESCRIPTION
* Check for root page
* If root page is detected, then prefix media file paths with content-root
* Invoke above logic before page load

Resolves: [MWPW-186252](https://jira.corp.adobe.com/browse/MWPW-186252)

**Test URLs:**
- Before: https://stage--genuine--adobecom.aem.live/genuine?gid=1BKVUDQIDF&gtoken=f37e2aa5-d86f-42cb-9c3e-d5bb723cf42a
- After: https://MWPW-186252-root-page--genuine--adobecom.aem.live/genuine?gid=1BKVUDQIDF&gtoken=f37e2aa5-d86f-42cb-9c3e-d5bb723cf42a

**Dev validation:**
Validated through browser overrides that images on the root page are not loading:
Test URL - https://www.stage.adobe.com/genuine.html?gid=1BKVUDQIDF&gtoken=f37e2aa5-d86f-42cb-9c3e-d5bb723cf42a

<img width="1277" height="928" alt="Screenshot 2026-01-15 at 5 09 26 PM" src="https://github.com/user-attachments/assets/4542cb9e-9d34-46d4-b508-3004515b839e" />



> Reference PR from CC repo - https://github.com/adobecom/cc/pull/312/files
