### PR TITLE
MWPW-188508: Limit local-nav link decoration to non-mega-menu items

### DIFF
--- a/genuine/scripts/decorate.js
+++ b/genuine/scripts/decorate.js
@@ -43,7 +43,9 @@ function goCartLinkAppend(link, paramsValue) {
 
 export function decorateLinks() {
   // Include links in header-localnav and main
-  const links = document.querySelectorAll('header.local-nav a:not([href^="tel:"]), main a:not([href^="tel:"])');
+  const localNavSelector = 'header.local-nav';
+  const localNavLinksSelector = `${localNavSelector} .feds-navItem:not(.feds-navItem--megaMenu) a:not([href^="tel:"])`;
+  const links = document.querySelectorAll(`${localNavLinksSelector}, main a:not([href^="tel:"])`);
   const cache = document.head.querySelector('meta[name="cache"]');
   const paramsValue = getUrlParams();
   const shouldAppendParams = cache?.content === 'on' && Object.keys(paramsValue).length > 0;
@@ -55,9 +57,9 @@ export function decorateLinks() {
   });
 
   const observer = new MutationObserver((_, obs) => {
-    const localNav = document.querySelector('header.local-nav');
+    const localNav = document.querySelector(localNavSelector);
     if (!localNav) return;
-    document.querySelectorAll('header.local-nav a:not([href^="tel:"])').forEach((link) => {
+    document.querySelectorAll(`${localNavLinksSelector}`).forEach((link) => {
       if (!processDisabledLink(link) && shouldAppendParams) {
         goCartLinkAppend(link, paramsValue);
       }


### PR DESCRIPTION
This change narrows link decoration in the local nav so we only process links inside non-mega-menu nav items, while keeping main-content link handling unchanged.

Resolves: [MWPW-188508](https://jira.corp.adobe.com/browse/MWPW-188508)

**Test URLs:**
**Test URLs:**
- Before: https://main--genuine--adobecom.aem.live/genuine/ic-ses-lp/shop?martech=off&gid=41N1AXBDMG&gtoken=c034592b-e547-43aa-82d5-9d42736566e4
- After: https://MWPW-188508-skip-mega-menu--genuine--adobecom.aem.live/genuine/ic-ses-lp/shop?martech=off&gid=41N1AXBDMG&gtoken=c034592b-e547-43aa-82d5-9d42736566e4

**Dev validation:**
_Using source overrides_
Test URLs:
- https://www.adobe.com/genuine/ic-ses-lp/shop.html?gid=41N1AXBDMG&gtoken=c034592b-e547-43aa-82d5-9d42736566e4
- https://www.adobe.com/genuine/ic-ses-lp.html?gid=41N1AXBDMG&gtoken=c034592b-e547-43aa-82d5-9d42736566e4


<img width="902" height="1022" alt="fix-skip-mega-menu" src="https://github.com/user-attachments/assets/55203186-9438-4d5d-8580-6af22893fb21" />

