### PR TITLE
[MWPW-191621] Upgrade BFPJS scripts.

### DIFF
--- a/genuine/scripts/scripts.js
+++ b/genuine/scripts/scripts.js
@@ -160,9 +160,10 @@ const CONFIG = {
     onDemand: false,
   },
   bfp: {
-    stageURL: 'https://d2d0g3srbng7g9.cloudfront.net/bfp-stg/v1/bfp.js',
-    prodURL: 'https://d1hmet3ucsy3j0.cloudfront.net/bfp/v1/bfp.js',
+    stageURL: 'https://bfp-stage.adobe.com/bfp/v1/bfp.min.js',
+    prodURL: 'https://bfp.adobe.com/bfp/v1/bfp.min.js',
     apiKey: 'genuine-bfp-milo',
+    clientId: 'adobedotcom-cc',
   },
   uniqueSiteId: 'genuine',
   mepLingoCountryToRegion: {


### PR DESCRIPTION
* The previous BFPJS endpoints were deprecated. Hence, updated them to the new urls.
* Also sending the clientID as per the request.

Resolves: [MWPW-191621](https://jira.corp.adobe.com/browse/MWPW-191621)

**Test URLs:**
- Before: https://main--genuine--adobecom.aem.live/?martech=off
- After: https://bfp-url--genuine--adobecom.aem.live/?martech=off

