### PR TITLE
MWPW-192857: aside-merch: Constrain split-right text-content width to merch card-width

### DIFF
--- a/genuine/blocks/aside-merch/aside-merch.css
+++ b/genuine/blocks/aside-merch/aside-merch.css
@@ -1,5 +1,4 @@
 :root {
-   --aside-merch-container-width: 83.4%;
     --aside-merch-max-width: 1396px;
     --aside-merch-min-height-tablet-small: 420px;
     --aside-merch-min-height-tablet-medium: 560px;
@@ -427,11 +426,11 @@
   margin-top: var(--spacing-s);
 }
 
-.aside-merch.split .foreground.container .text > [class^="heading-"]:not(merch-card *),
-.aside-merch.split .foreground.container .text > [class^="body-"]:not(merch-card *),
-.aside-merch.split .foreground.container .text > [class^="detail-"]:not(merch-card *),
-.aside-merch.split .foreground.container .text > p:not(merch-card *) {
-  max-width: var(--aside-merch-container-width);
+.aside-merch.split-right .foreground.container .text > [class^="heading-"]:not(merch-card *),
+.aside-merch.split-right .foreground.container .text > [class^="body-"]:not(merch-card *),
+.aside-merch.split-right .foreground.container .text > [class^="detail-"]:not(merch-card *),
+.aside-merch.split-right .foreground.container .text > p:not(merch-card *) {
+  max-width: var(--aside-merch-half-card-width);
 }
 
 @media screen and (min-width: 600px) {

--- a/genuine/blocks/aside-merch/aside-merch.css
+++ b/genuine/blocks/aside-merch/aside-merch.css
@@ -426,11 +426,36 @@
   margin-top: var(--spacing-s);
 }
 
-.aside-merch.split-right .foreground.container .text > [class^="heading-"]:not(merch-card *),
-.aside-merch.split-right .foreground.container .text > [class^="body-"]:not(merch-card *),
-.aside-merch.split-right .foreground.container .text > [class^="detail-"]:not(merch-card *),
-.aside-merch.split-right .foreground.container .text > p:not(merch-card *) {
+.aside-merch.no-media .foreground.container .text > [class^="heading-"]:not(merch-card *),
+.aside-merch.no-media .foreground.container .text > [class^="body-"]:not(merch-card *),
+.aside-merch.no-media .foreground.container .text > [class^="detail-"]:not(merch-card *),
+.aside-merch.no-media .foreground.container .text > p:not(merch-card *) {
+  max-width: calc(2 * var(--aside-merch-center-card-width) + var(--spacing-m));
+}
+
+.aside-merch.half .foreground.container .text > [class^="heading-"]:not(merch-card *),
+.aside-merch.half .foreground.container .text > [class^="body-"]:not(merch-card *),
+.aside-merch.half .foreground.container .text > [class^="detail-"]:not(merch-card *),
+.aside-merch.half .foreground.container .text > p:not(merch-card *) {
   max-width: var(--aside-merch-half-card-width);
+}
+
+.aside-merch.one-third .foreground.container .text > [class^="heading-"]:not(merch-card *),
+.aside-merch.one-third .foreground.container .text > [class^="body-"]:not(merch-card *),
+.aside-merch.one-third .foreground.container .text > [class^="detail-"]:not(merch-card *),
+.aside-merch.one-third .foreground.container .text > p:not(merch-card *) {
+  max-width: calc(2 * var(--aside-merch-one-third-card-width) + var(--spacing-xs));
+}
+
+
+
+@media (max-width: 768px) {
+  .aside-merch.one-third .foreground.container .text > [class^="heading-"]:not(merch-card *),
+  .aside-merch.one-third .foreground.container .text > [class^="body-"]:not(merch-card *),
+  .aside-merch.one-third .foreground.container .text > [class^="detail-"]:not(merch-card *),
+  .aside-merch.one-third .foreground.container .text > p:not(merch-card *) {
+    max-width: var(--aside-merch-one-third-card-width);
+  }
 }
 
 @media screen and (min-width: 600px) {
@@ -569,6 +594,7 @@
   }
 
   .aside-merch.split.one-third .foreground.container .text {
+    flex-direction: column;
     flex: 1 0 100%;
     max-width: 100%;
   }
@@ -591,6 +617,7 @@
   }
 
   .aside-merch.split.half .foreground.container .text {
+    flex-direction: column;
     flex: 1 0 100%;
     max-width: 100%;
     padding: 0 var(--spacing-xl);

--- a/genuine/blocks/aside-merch/aside-merch.css
+++ b/genuine/blocks/aside-merch/aside-merch.css
@@ -1,4 +1,5 @@
 :root {
+   --aside-merch-container-width: 83.4%;
     --aside-merch-max-width: 1396px;
     --aside-merch-min-height-tablet-small: 420px;
     --aside-merch-min-height-tablet-medium: 560px;
@@ -424,6 +425,13 @@
 
 .aside-merch merch-card [slot="body-xs"] p:has(a) + p:not(:has(a)) {
   margin-top: var(--spacing-s);
+}
+
+.aside-merch.split .foreground.container .text > [class^="heading-"]:not(merch-card *),
+.aside-merch.split .foreground.container .text > [class^="body-"]:not(merch-card *),
+.aside-merch.split .foreground.container .text > [class^="detail-"]:not(merch-card *),
+.aside-merch.split .foreground.container .text > p:not(merch-card *) {
+  max-width: var(--aside-merch-container-width);
 }
 
 @media screen and (min-width: 600px) {


### PR DESCRIPTION
* Constrain split-right text-content width to merch card-width

Resolves: [MWPW-192857](https://jira.corp.adobe.com/browse/MWPW-192857)

**Test URLs:**
- Before: https://stage--genuine--adobecom.aem.page/genuine/drafts/drashti/aside-merch-half?martech=off
- After: https://mwpw-192857-aside-merch-width--genuine--adobecom.aem.page/genuine/drafts/drashti/aside-merch-half?martech=off

Additional test URL - https://mwpw-192857-aside-merch-width--genuine--adobecom.aem.page/genuine/drafts/drashti/aside-merch-no-image

**Dev validation**:
<img width="3366" height="1842" alt="image" src="https://github.com/user-attachments/assets/116a510d-8152-4a9d-bd61-c7bf620c8bc9" />
<img width="3360" height="1780" alt="image" src="https://github.com/user-attachments/assets/8542cc10-5784-4fa5-bbdb-a31ebafb4bf4" />




